### PR TITLE
Update README to include example command 'linode stackscript list'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ linode nodebalancer node-list mynodebalancer 80
 Actions can be performed on StackScripts.
 
 ```
+linode stackscript list
 linode stackscript create --label "StackScript Name" --codefile "/path/myscript.sh" --distribution "Debian 7"
 linode stackscript show My-StackScript-Label
 linode stackscript source mystackscript > myscript.sh


### PR DESCRIPTION
Very simple addition to the README to add 'linode stackscript list' sample command.  It was the only one that didn't have the 'list' command that I noticed.
