### PR TITLE
Fixed incorrect short option for --group on group command

### DIFF
--- a/lib/Linode/CLI/Util.pm
+++ b/lib/Linode/CLI/Util.pm
@@ -136,7 +136,7 @@ our %paramsdef = (
         'group' => {
             'options' => {
                 'label' => 'label|l=s@',
-                'group' => 'group|n=s'
+                'group' => 'group|g=s'
             },
             'run' => 'update',
         },


### PR DESCRIPTION
Was '-n' but it's '-g' in all other contexts, and the help indicates it should be '-g'.
