### PR TITLE
OS X installation changed to single command that will tap and install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ sudo apt-get install linode-cli
 Installing the packaged version of Linode CLI on Mac OS X requires Homebrew: http://brew.sh
 
 ```
-brew tap linode/cli
-brew install linode-cli
+brew install linode/cli/linode-cli
 ```
 
 ### Others


### PR DESCRIPTION
Recent versions of brew allow for tap and install in a single command by prefixing the formula to install with the tap path.