### PR TITLE
updated man page for some confusing param aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,9 +353,9 @@ Create and start a new Linode.
 
 **-l**, **--label**: Required. A Linode to operate on.
 
-**-L**, **--location**: Required. The datacenter to use for deployment. Locations are Atlanta, Dallas, Fremont, London, Newark, and Tokyo.
+**-L**, **--location**, **--datacenter**: Required. The datacenter to use for deployment. Locations are Atlanta, Dallas, Fremont, London, Newark, and Tokyo.
 
-**-d**, **--distribution**: Required when not using imageid. Distribution name or DistributionID to deploy.
+**-d**, **--distribution**, **distro**: Required when not using imageid. Distribution name or DistributionID to deploy.
 
 **-i**, **--imageid**: Required when not using distribution. The ID of the gold-master image to use for deployment.
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Create and start a new Linode.
 
 **-L**, **--location**, **--datacenter**: Required. The datacenter to use for deployment. Locations are Atlanta, Dallas, Fremont, London, Newark, and Tokyo.
 
-**-d**, **--distribution**, **distro**: Required when not using imageid. Distribution name or DistributionID to deploy.
+**-d**, **--distribution**: Required when not using imageid. Distribution name or DistributionID to deploy.
 
 **-i**, **--imageid**: Required when not using distribution. The ID of the gold-master image to use for deployment.
 


### PR DESCRIPTION
datacenter and distros are aliases, but they are not indicated so in the man page.