### PR TITLE
Add note regarding seg faults on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Installing the packaged version of Linode CLI on Mac OS X requires Homebrew: htt
 brew install linode/cli/linode-cli
 ```
 
+#### Mac OS X segmentation faults
+
+Linode-cli must be built using the system perl, so if you end up with segmentation faults when running `linode` on OSX, try 
+
+```
+brew unlink perl
+brew uninstall linode-cli
+brew install linode-cli
+```
+
 ### Others
 
 You'll need the following Perl modules. They can be installed from the CPAN using your preferred method.


### PR DESCRIPTION
Hi there!

`brew install linode/cli/linode-cli` succeeds on OSX El Capitan, but segmentation faults when running the resulting `linode` command. This seems to be due to some SSL changes in El Capitan.

This PR adds a note to the README about a workaround. 