### PR TITLE
Plan/location update

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,13 +392,13 @@ Create and start a new Linode.
 
 **-l**, **--label**: Required. A Linode to operate on.
 
-**-L**, **--location**, **--datacenter**: Required. The datacenter to use for deployment. Locations are Atlanta, Dallas, Fremont, London, Newark, and Tokyo.
+**-L**, **--location**, **--datacenter**: Required. The datacenter to use for deployment. Locations are Atlanta, Dallas, Frankfurt, Fremont, London, Newark, Singapore, Shinagawa.
 
 **-d**, **--distribution**: Required when not using imageid. Distribution name or DistributionID to deploy.
 
 **-i**, **--imageid**: Required when not using distribution. The ID of the gold-master image to use for deployment.
 
-**-p**, **--plan**: Required. The Plan to deploy. Plans are linode2048, linode4096, linode8192, linode12288, linode24576, linode49152, linode65536, linode81920, and linode122880.
+**-p**, **--plan**: Required. The Plan to deploy. Plans are linode1024, linode2048, linode4096, linode8192, linode12288, linode16384, linode24576, linode32768, linode49152, linode61440, linode65536, linode81920, linode102400, and linode204800.
 
 **-P**, **--password**: Required. The root user's password.  Needs to be at least 6 characters and contain at least two of these four character classes: lower case letters, upper case letters, numbers, and punctuation.
 
@@ -464,7 +464,7 @@ Resize a Linode to a new plan size, and issue a boot job.
 
 **-l**, **--label**: A Linode to operate on.
 
-**-p**, **--plan**: The Plan to resize to. Plans are linode2048, linode4096, linode8192, linode12288, linode24576, linode49152, linode65536, linode81920, and linode122880.
+**-p**, **--plan**: The Plan to resize to. Plans are linode1024, linode2048, linode4096, linode8192, linode12288, linode16384, linode24576, linode32768, linode49152, linode61440, linode65536, linode81920, linode102400, and linode204800.
 
 **-w**, **--wait**: Optional. Amount of time (in minutes) to wait for human output. Using the flag only, will use the default of 20.
 

--- a/lib/Linode/CLI/Object/Linode.pm
+++ b/lib/Linode/CLI/Object/Linode.pm
@@ -103,7 +103,7 @@ sub list {
                     $humanyn{ $grouped_objects->{$group}{$object}{backupsenabled} },
                     human_displaymemory( $grouped_objects->{$group}{$object}{totalhd} ),
                     human_displaymemory( $grouped_objects->{$group}{$object}{totalram} ),
-                    format_len( $grouped_objects->{$group}{$object}{create_dt} ),
+                    format_len( $grouped_objects->{$group}{$object}{create_dt}, $colw[6] ),
                 );
 
                 push @$out_arrayref, colorize( $line );

--- a/linode-linode
+++ b/linode-linode
@@ -135,7 +135,7 @@ Required. A Linode to operate on.
 
 =item B<-L>, B<--location>
 
-Required. The datacenter to use for deployment. Locations are Atlanta, Dallas, Fremont, London, Newark, and Tokyo.
+Required. The datacenter to use for deployment. Locations are Atlanta, Dallas, Frankfurt, Fremont, London, Newark, Singapore, Shinagawa.
 
 =item B<-d>, B<--distribution>
 
@@ -147,7 +147,7 @@ Required when not using distribution. The ID of the gold-master image to use for
 
 =item B<-p>, B<--plan>
 
-Required. The Plan to deploy. Plans are linode1024, linode2048, linode4096, linode8192, linode16384, linode24576, linode32768, and linode40960.
+Required. The Plan to deploy. Plans are linode1024, linode2048, linode4096, linode8192, linode12288, linode16384, linode24576, linode32768, linode49152, linode61440, linode65536, linode81920, linode102400, and linode204800.
 
 =item B<-P>, B<--password>
 
@@ -339,7 +339,7 @@ A Linode to operate on.
 
 =item B<-p>, B<--plan>
 
-The Plan to resize to. Plans are linode2048, linode4096, linode8192, linode12288, linode24576, linode49152, linode65536, linode81920, and linode122880.
+The Plan to resize to. Plans are linode1024, linode2048, linode4096, linode8192, linode12288, linode16384, linode24576, linode32768, linode49152, linode61440, linode65536, linode81920, linode102400, and linode204800.
 
 =item B<-w>, B<--wait>
 

--- a/linode-nodebalancer
+++ b/linode-nodebalancer
@@ -123,7 +123,7 @@ Required. The name of the NodeBalancer.
 
 =item B<-L> B<--location>
 
-Required. The datacenter to use for deployment. Locations are Dallas, Fremont, Atlanta, Newark, London, and Tokyo.
+Required. The datacenter to use for deployment. Locations are Atlanta, Dallas, Frankfurt, Fremont, London, Newark, Singapore, Shinagawa.
 
 =item B<-t> B<--payment-term>
 


### PR DESCRIPTION
Update the documentation strings to reflect Linode's current offerings. Everything worked fine using the values for their newer plans and locations, but I figured this should be reflected in the documentation.