### PR TITLE
Add a `linode ip-list` command

### DIFF
--- a/lib/Linode/CLI.pm
+++ b/lib/Linode/CLI.pm
@@ -172,6 +172,8 @@ sub list {
         $sub = 'disklist';
     } elsif ($self->{mode} eq 'linode' && $self->{_opts}->{action} eq 'image-list') {
         $sub = 'imagelist';
+    } elsif ($self->{mode} eq 'linode' && $self->{_opts}->{action} eq 'ip-list') {
+        $sub = 'iplist';
     }
 
     my $list_result = try {

--- a/lib/Linode/CLI/Util.pm
+++ b/lib/Linode/CLI/Util.pm
@@ -157,6 +157,14 @@ our %paramsdef = (
             },
             'run'       => 'add_ip',
         },
+        'list-ip' => { 'alias' => 'ip-list' },
+        'ip-list' => {
+            'options' => {
+                'label'   => 'label|l=s@',
+                'private' => 'private',
+            },
+            'run' => 'list',
+        },
         'configure' => {
             'run' => 'configure',
             'warmcache' => [ 'plan', 'distribution', 'datacenter' ]

--- a/linode-linode
+++ b/linode-linode
@@ -57,6 +57,8 @@ B<linode-linode> [B<-a> action] [action-options...] [options...]
 
 =item S<-a ip-add,     --action ip-add      add an IP address to a Linode>
 
+=item S<-a ip-list,    --action ip-list     list IP address(es) of a Linode>
+
 =item S<-a delete,     --action delete      completely delete a Linode>
 
 =item S<-a list,       --action list        list info about Linodes>
@@ -364,6 +366,26 @@ A Linode to operate on.
 =item B<--private>
 
 Add a private IP address instead of a public one.
+
+=back
+
+=back
+
+=head2 IP-LIST
+
+=over 8
+
+=item List the IP address(es) assigned to a Linode.
+
+=over 8
+
+=item B<-l>, B<--label>
+
+A Linode to operate on.
+
+=item B<--private>
+
+List only the private IP address.
 
 =back
 


### PR DESCRIPTION
This implements an action similar to `linode show <label>` except it
limits information only to IP addresses, with an optional filter for
showing only private IP:

```
$ linode ip-list --help
  ip-List:
    List the IP address(es) assigned to a Linode.

            -l, --label
                    A Linode to operate on.

            --private
                    List only the private IP address.

$ linode ip-list foo bar
+ -------------------------------- + ---------------- +
| name                             | ips              |
+ -------------------------------- + ---------------- +
| foo                              | 66.xx.xxx.xxx    |
| foo                              | 192.168.xxx.xxx  |
+ -------------------------------- + ---------------- +

+ -------------------------------- + ---------------- +
| name                             | ips              |
+ -------------------------------- + ---------------- +
| bar                              | 192.168.xxx.x    |
| bar                              | 173.xxx.xxx.xx   |
+ -------------------------------- + ---------------- +

$ linode ip-list foo bar -j --private

{
   "foo" : {
      "request_error" : "",
      "request_action" : "ip-list",
      "ips" : [
         "192.168.xxx.xxx"
      ]
   },
   "bar" : {
      "request_error" : "",
      "request_action" : "ip-list",
      "ips" : [
         "192.168.xxx.xxx"
      ]
   }
}
```

Also aliased to `linode list-ip` action.  Perhaps fixes #40 as well.